### PR TITLE
[performance] Implement loadUnaligned for big endian

### DIFF
--- a/src/core/BitReader.hpp
+++ b/src/core/BitReader.hpp
@@ -229,7 +229,7 @@ private:
          * for the requested number of bits, then refill the whole bit buffer with one unaligned memory read.
          * This makes the assumption that read2 is only ever called when all the current bit buffer bits are
          * not enough. */
-        if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN == Endian::LITTLE ) ) {
+        if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN != Endian::UNKNOWN ) ) {
             constexpr bit_count_t BYTES_WANTED = sizeof( BitBuffer );
             constexpr bit_count_t BITS_WANTED = sizeof( BitBuffer ) * CHAR_BIT;
 
@@ -395,7 +395,7 @@ private:
         assert( bitsWanted > 0 );
 
         if ( UNLIKELY( bitsWanted > bitBufferSize() ) ) [[unlikely]] {
-            if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN == Endian::LITTLE ) ) {
+            if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN != Endian::UNKNOWN ) ) {
                 if ( LIKELY( m_inputBufferPosition + sizeof( BitBuffer ) < m_inputBuffer.size() ) ) [[likely]] {
                     /* There is no way around this special case because of the damn undefined behavior when shifting! */
                     if ( bitBufferSize() == 0 ) {
@@ -429,7 +429,7 @@ private:
             try {
                 /* In the case of the shortcut for filling the bit buffer by reading 64-bit, don't inline
                  * the very rarely used fallback to keep this function rather small for inlining. */
-                if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN == Endian::LITTLE ) ) {
+                if constexpr ( !MOST_SIGNIFICANT_BITS_FIRST && ( ENDIAN != Endian::UNKNOWN ) ) {
                     /* This point should only happen rarely, e.g., when the byte buffer needs to be refilled. */
                     refillBitBuffer();
                 } else {

--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -540,6 +540,8 @@ enum class Endian
 constexpr Endian ENDIAN =
 #if defined( __BYTE_ORDER__ ) && defined( __ORDER_LITTLE_ENDIAN__ ) && ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
     Endian::LITTLE
+#elif defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && ( __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ )
+    Endian::BIG
 #else
     Endian::UNKNOWN
 #endif
@@ -556,7 +558,14 @@ template<typename T>
 loadUnaligned( const void* data )
 {
     T result{ 0 };
-    std::memcpy( &result, data, sizeof( result ) );
+    if constexpr ( ENDIAN == Endian::LITTLE ) {
+        std::memcpy( &result, data, sizeof( result ) );
+    } else {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        for (size_t i = 0; i < sizeof(T); ++i) {
+            result |= static_cast<T>(bytes[i]) << (i * 8);
+        }
+    }
     return result;
 }
 


### PR DESCRIPTION
I'm looking at using this project to run on a solaris-sparc system which uses big endian, however, I notice it is quite cpu expensive. 

One area I noticed was the fallback cost to not using `loadUnaligned` in BitReader. To overcome the byte ordering issues seen by memcpy, on big endian we can bitshift into the `unit*_t` value. For my test data, this leads to ~10-15% reduction in CPU.

```
$ time gzip -d test.tar.gz -c > /dev/null

real    0m5.890s
user    0m5.824s
sys     0m0.066s
```

```
$ time rapidgzip.before -d test.tar.gz -P 8 --no-verify -c > /dev/null

real    0m0.992s
user    0m7.311s
sys     0m0.236s
```

```
$ time rapidgzip.after -d test.tar.gz -P 8 --no-verify -c > /dev/null

real    0m0.867s
user    0m6.353s
sys     0m0.222s
```

_(note I am currently using `--no-verify` because there is some separate issue for calculating crc on big endian)_