### PR TITLE
[performance] forceinline getDistance

### DIFF
--- a/src/rapidgzip/gzip/deflate.hpp
+++ b/src/rapidgzip/gzip/deflate.hpp
@@ -755,7 +755,7 @@ private:
 
 #endif
 
-    [[nodiscard]] std::pair<uint16_t, Error>
+    [[nodiscard]] forceinline std::pair<uint16_t, Error>
     getDistance( BitReader& bitReader ) const;
 
     /**
@@ -1155,6 +1155,7 @@ Block<ENABLE_STATISTICS>::readDynamicHuffmanCoding( BitReader& bitReader )
 
 
 template<bool ENABLE_STATISTICS>
+forceinline
 std::pair<uint16_t, Error>
 Block<ENABLE_STATISTICS>::getDistance( BitReader& bitReader ) const
 {


### PR DESCRIPTION
When getDistance is inlined I notice about a 15% cpu cost reduction overall. I believe this may be due to the creation of many small struct responses in the tight loop during `readInternalCompressed` if it is not inlined.

Before:
```
$ time rapidgzip.before -d test.tar.gz -P 8 --no-verify -c > /dev/null

real    0m0.993s
user    0m7.366s
sys     0m0.228s
```

After
```
$ time rapidgzip.after -d test.tar.gz -P 8 --no-verify -c > /dev/null

real    0m0.848s
user    0m6.184s
sys     0m0.236s
```